### PR TITLE
fix: always display full-width symbol when long press . (keyCode 46)

### DIFF
--- a/LimeStudio/app/src/main/java/net/toload/main/hd/keyboard/LIMEKeyboardBaseView.java
+++ b/LimeStudio/app/src/main/java/net/toload/main/hd/keyboard/LIMEKeyboardBaseView.java
@@ -1502,7 +1502,7 @@ public class LIMEKeyboardBaseView extends View implements PointerTracker.UIProxy
     protected boolean onLongPress(Key popupKey) {
         // TODO if popupKey.popupCharacters has only one letter, send it as key without opening
         // mini keyboard.
-        if (!(!mLIMEPref.getLanguageMode() && popupKey.codes[0] == 46))//(不論拼音pinyin,速成ecj,倉頡cj, 注音phonetic輸入法)只處理非純英文模式鍵盤時長按 . 出現的全形符號選單 (前次修改是為了阻擋純英鍵盤長按出現的德文西文等字母)
+        if (popupKey.codes[0] != 46)//(不論拼音pinyin,速成ecj,倉頡cj, 注音phonetic輸入法) 長按 . 出現的全形符號選單 (前次修改是為了阻擋純英鍵盤長按出現的德文西文等字母)
             return false;
 
         View container = mMiniKeyboardCache.get(popupKey);

--- a/LimeStudio/app/src/main/res/xml/lime.xml
+++ b/LimeStudio/app/src/main/res/xml/lime.xml
@@ -78,9 +78,7 @@
         <Key limehd:codes="-9" limehd:keyLabel="EN" limehd:isModifier="true" limehd:keyWidth="10%p" />
         <Key limehd:codes="44" limehd:keyLabel="," limehd:keyWidth="10%p"/>
         <Key limehd:codes="32" limehd:keyIcon="@drawable/sym_flat_keyboard_space"  limehd:keyWidth="30%p" limehd:isRepeatable="true"/>
-        <Key limehd:codes="46" 
-        		limehd:keyLabel="." 
-				 limehd:popupKeyboard="@xml/popup_c_punctuation"  
+        <Key limehd:codes="46" limehd:keyLabel="." limehd:popupKeyboard="@xml/popup_c_punctuation"
         		limehd:keyWidth="10%p"/>
         <Key limehd:codes="-2"  limehd:keyLabel="@string/label_symbol_key" limehd:isModifier="true"/>
         <Key limehd:codes="10" limehd:keyIcon="@drawable/sym_keyboard_return_light" limehd:isModifier="true" limehd:keyWidth="15%p" limehd:keyEdgeFlags="right"/>

--- a/LimeStudio/app/src/main/res/xml/lime_abc.xml
+++ b/LimeStudio/app/src/main/res/xml/lime_abc.xml
@@ -87,9 +87,7 @@
         <Key limehd:codes="-10" limehd:keyLabel="中"  limehd:isModifier="true" limehd:keyWidth="10%p" />
         <Key limehd:codes="44" limehd:keyLabel="," limehd:keyWidth="10%p"/>
         <Key limehd:codes="32" limehd:keyIcon="@drawable/sym_flat_keyboard_space"  limehd:keyWidth="30%p" limehd:isRepeatable="true"/>
-        <Key limehd:codes="46" 
-        		limehd:keyLabel="."
-        		 limehd:popupKeyboard="@xml/popup_c_punctuation"   
+        <Key limehd:codes="46" limehd:keyLabel="." limehd:popupKeyboard="@xml/popup_c_punctuation"
         		limehd:keyWidth="10%p"/>
         <Key limehd:codes="-2"  limehd:keyLabel="@string/label_symbol_key" limehd:isModifier="true"/>
         <Key limehd:codes="10" limehd:keyIcon="@drawable/sym_keyboard_return_light" limehd:isModifier="true" limehd:keyWidth="15%p" limehd:keyEdgeFlags="right"/>

--- a/LimeStudio/app/src/main/res/xml/lime_cj.xml
+++ b/LimeStudio/app/src/main/res/xml/lime_cj.xml
@@ -76,9 +76,7 @@
         <Key limehd:codes="-9" limehd:keyLabel="EN"  limehd:isModifier="true" limehd:keyWidth="10%p" />
         <Key limehd:codes="44" limehd:keyLabel="," limehd:keyWidth="10%p"/>
         <Key limehd:codes="32" limehd:keyIcon="@drawable/sym_flat_keyboard_space"  limehd:keyWidth="30%p" limehd:isRepeatable="true"/>
-        <Key limehd:codes="46" 
-        		limehd:keyLabel="."
-				 limehd:popupKeyboard="@xml/popup_c_punctuation"   
+        <Key limehd:codes="46" limehd:keyLabel="." limehd:popupKeyboard="@xml/popup_c_punctuation"
         		limehd:keyWidth="10%p"/>
         <Key limehd:codes="-2" limehd:keyLabel="123" limehd:isModifier="true" />
         <Key limehd:codes="10" limehd:keyIcon="@drawable/sym_keyboard_return_light" limehd:isModifier="true" limehd:keyWidth="15%p" limehd:keyEdgeFlags="right"/>

--- a/LimeStudio/app/src/main/res/xml/lime_cj_number.xml
+++ b/LimeStudio/app/src/main/res/xml/lime_cj_number.xml
@@ -89,9 +89,7 @@
         <Key limehd:codes="-9" limehd:keyLabel="EN"  limehd:isModifier="true" limehd:keyWidth="10%p" />
         <Key limehd:codes="44" limehd:keyLabel="," limehd:keyWidth="10%p"/>
         <Key limehd:codes="32" limehd:keyIcon="@drawable/sym_flat_keyboard_space"  limehd:keyWidth="30%p" limehd:isRepeatable="true"/>
-        <Key limehd:codes="46" 
-        		limehd:keyLabel="."
-				 limehd:popupKeyboard="@xml/popup_c_punctuation"   
+        <Key limehd:codes="46" limehd:keyLabel="." limehd:popupKeyboard="@xml/popup_c_punctuation"
         		limehd:keyWidth="10%p"/>
         <Key limehd:codes="-2" limehd:keyLabel="123" limehd:isModifier="true" />
         <Key limehd:codes="10" limehd:keyIcon="@drawable/sym_keyboard_return_light" limehd:isModifier="true" limehd:keyWidth="15%p" limehd:keyEdgeFlags="right"/>

--- a/LimeStudio/app/src/main/res/xml/lime_dayi.xml
+++ b/LimeStudio/app/src/main/res/xml/lime_dayi.xml
@@ -101,9 +101,7 @@
 			limehd:keyIcon="@drawable/sym_flat_keyboard_space"
 			limehd:keyWidth="30%p" limehd:isRepeatable="true" />
 		<Key limehd:codes="44" limehd:keyLabel="," limehd:keyWidth="10%p" />
-		<Key limehd:codes="46" 
-				limehd:keyLabel="."
-				 limehd:popupKeyboard="@xml/popup_c_punctuation"   
+		<Key limehd:codes="46" limehd:keyLabel="." limehd:popupKeyboard="@xml/popup_c_punctuation"
 				limehd:keyWidth="10%p" />
 		<Key limehd:codes="47" limehd:keyLabel="/" limehd:keyWidth="10%p" />
 		<Key limehd:codes="10" limehd:keyIcon="@drawable/sym_keyboard_return_light" limehd:isModifier="true"

--- a/LimeStudio/app/src/main/res/xml/lime_english_number.xml
+++ b/LimeStudio/app/src/main/res/xml/lime_english_number.xml
@@ -148,7 +148,7 @@
         <Key limehd:codes="32" limehd:keyIcon="@drawable/sym_keyboard_space_light"
 
                 limehd:keyWidth="15%p" limehd:isRepeatable="true"/>
-        <Key limehd:keyLabel="."  limehd:popupKeyboard="@xml/popup_punctuation"
+        <Key limehd:codes="46" limehd:keyLabel="."  limehd:popupKeyboard="@xml/popup_punctuation"
                 limehd:keyWidth="10%p"/>
         <Key limehd:codes="-2"  limehd:keyLabel="@string/label_symbol_key" limehd:isModifier="true" limehd:keyWidth="10%p" />
         <Key limehd:codes="10" limehd:keyIcon="@drawable/sym_keyboard_return_light" limehd:isModifier="true"
@@ -166,7 +166,7 @@
         <Key limehd:codes="32" limehd:keyIcon="@drawable/sym_keyboard_space_light"
 
                 limehd:keyWidth="15%p" limehd:isRepeatable="true"/>
-        <Key limehd:keyLabel="."  limehd:popupKeyboard="@xml/popup_punctuation"
+        <Key limehd:codes="46" limehd:keyLabel="."  limehd:popupKeyboard="@xml/popup_punctuation"
                 limehd:keyWidth="10%p"/>
         <Key limehd:codes="-2"  limehd:keyLabel="@string/label_symbol_key" limehd:isModifier="true" limehd:keyWidth="10%p" />
         <Key limehd:codes="10" limehd:keyIcon="@drawable/sym_keyboard_return_light" limehd:isModifier="true"

--- a/LimeStudio/app/src/main/res/xml/lime_et26.xml
+++ b/LimeStudio/app/src/main/res/xml/lime_et26.xml
@@ -90,9 +90,7 @@
         <Key limehd:codes="-9" limehd:keyLabel="EN" limehd:isModifier="true" limehd:keyWidth="10%p" />
         <Key limehd:codes="44" limehd:keyLabel="," limehd:keyWidth="10%p"/>
         <Key limehd:codes="32" limehd:keyIcon="@drawable/sym_flat_keyboard_space"  limehd:keyWidth="30%p" limehd:isRepeatable="true"/>
-        <Key limehd:codes="46" 
-        		limehd:keyLabel="."
-        		 limehd:popupKeyboard="@xml/popup_c_punctuation"   
+        <Key limehd:codes="46" limehd:keyLabel="." limehd:popupKeyboard="@xml/popup_c_punctuation"
         		limehd:keyWidth="10%p"/>
         <Key limehd:codes="-2"  limehd:keyLabel="@string/label_symbol_key" limehd:isModifier="true"/>
         <Key limehd:codes="10" limehd:keyIcon="@drawable/sym_keyboard_return_light" limehd:isModifier="true" limehd:keyWidth="15%p" limehd:keyEdgeFlags="right"/>

--- a/LimeStudio/app/src/main/res/xml/lime_hs.xml
+++ b/LimeStudio/app/src/main/res/xml/lime_hs.xml
@@ -93,9 +93,7 @@
 				/>
 		<Key limehd:codes="45" limehd:keyLabel="-" />
 		<Key limehd:codes="61" limehd:keyLabel="=" />
-		<Key limehd:codes="46" 
-				limehd:keyLabel="."
-				 limehd:popupKeyboard="@xml/popup_c_punctuation"   
+		<Key limehd:codes="46" limehd:keyLabel="." limehd:popupKeyboard="@xml/popup_c_punctuation"
 				limehd:keyWidth="10%p" />
 		<Key limehd:codes="32"
 			limehd:keyIcon="@drawable/sym_flat_keyboard_space"

--- a/LimeStudio/app/src/main/res/xml/lime_hs_shift.xml
+++ b/LimeStudio/app/src/main/res/xml/lime_hs_shift.xml
@@ -95,9 +95,7 @@
 				/>
 		<Key limehd:codes="45" limehd:keyLabel="-" />
 		<Key limehd:codes="61" limehd:keyLabel="=" />
-		<Key limehd:codes="46" 
-				limehd:keyLabel="."
-				 limehd:popupKeyboard="@xml/popup_c_punctuation"   
+		<Key limehd:codes="46" limehd:keyLabel="." limehd:popupKeyboard="@xml/popup_c_punctuation"
 				limehd:keyWidth="10%p" />
 		<Key limehd:codes="32"
 			limehd:keyIcon="@drawable/sym_flat_keyboard_space"

--- a/LimeStudio/app/src/main/res/xml/lime_hsu.xml
+++ b/LimeStudio/app/src/main/res/xml/lime_hsu.xml
@@ -90,9 +90,7 @@
         <Key limehd:codes="-9" limehd:keyLabel="EN" limehd:isModifier="true" limehd:keyWidth="10%p" />
         <Key limehd:codes="44" limehd:keyLabel="," limehd:keyWidth="10%p"/>
         <Key limehd:codes="32" limehd:keyIcon="@drawable/sym_flat_keyboard_space"  limehd:keyWidth="30%p" limehd:isRepeatable="true"/>
-        <Key limehd:codes="46" 
-        		limehd:keyLabel="."
-        		 limehd:popupKeyboard="@xml/popup_c_punctuation"   
+        <Key limehd:codes="46" limehd:keyLabel="." limehd:popupKeyboard="@xml/popup_c_punctuation"
         		limehd:keyWidth="10%p"/>
         <Key limehd:codes="-2"  limehd:keyLabel="@string/label_symbol_key" limehd:isModifier="true"/>
         <Key limehd:codes="10" limehd:keyIcon="@drawable/sym_keyboard_return_light" limehd:isModifier="true" limehd:keyWidth="15%p" limehd:keyEdgeFlags="right"/>

--- a/LimeStudio/app/src/main/res/xml/lime_number.xml
+++ b/LimeStudio/app/src/main/res/xml/lime_number.xml
@@ -91,9 +91,7 @@
         <Key limehd:codes="-9" limehd:keyLabel="EN" limehd:isModifier="true" limehd:keyWidth="10%p" />
         <Key limehd:codes="44" limehd:keyLabel="," limehd:keyWidth="10%p"/>
         <Key limehd:codes="32" limehd:keyIcon="@drawable/sym_flat_keyboard_space"  limehd:keyWidth="30%p" limehd:isRepeatable="true"/>
-        <Key limehd:codes="46" 
-        		limehd:keyLabel="."
-        		 limehd:popupKeyboard="@xml/popup_c_punctuation"   
+        <Key limehd:codes="46" limehd:keyLabel="." limehd:popupKeyboard="@xml/popup_c_punctuation"
         		limehd:keyWidth="10%p"/>
         <Key limehd:codes="-2"  limehd:keyLabel="@string/label_symbol_key" limehd:isModifier="true"/>
         <Key limehd:codes="10" limehd:keyIcon="@drawable/sym_keyboard_return_light" limehd:isModifier="true" limehd:keyWidth="15%p" limehd:keyEdgeFlags="right"/>

--- a/LimeStudio/app/src/main/res/xml/lime_number_symbol.xml
+++ b/LimeStudio/app/src/main/res/xml/lime_number_symbol.xml
@@ -95,9 +95,7 @@
 		<Key limehd:codes="32" limehd:keyIcon="@drawable/sym_flat_keyboard_space"
 				limehd:keyWidth="15%p" limehd:isRepeatable="true" />
 		<Key limehd:codes="44" limehd:keyLabel=","/>
-		<Key limehd:codes="46" 
-				limehd:keyLabel="."
-				 limehd:popupKeyboard="@xml/popup_c_punctuation"   
+		<Key limehd:codes="46" limehd:keyLabel="." limehd:popupKeyboard="@xml/popup_c_punctuation"
 				limehd:keyWidth="10%p" />
 		<Key limehd:codes="47" limehd:keyLabel="/" />
 		<Key limehd:codes="45" limehd:keyLabel="-" />

--- a/LimeStudio/app/src/main/res/xml/lime_url.xml
+++ b/LimeStudio/app/src/main/res/xml/lime_url.xml
@@ -144,7 +144,7 @@
         <Key limehd:codes="32" limehd:keyIcon="@drawable/sym_keyboard_space_light"
 
                 limehd:keyWidth="15%p" limehd:isRepeatable="true"/>
-        <Key limehd:keyLabel="."  limehd:popupKeyboard="@xml/popup_punctuation"
+        <Key limehd:codes="46" limehd:keyLabel="."  limehd:popupKeyboard="@xml/popup_punctuation"
                 limehd:keyWidth="10%p"/>
         <Key limehd:codes="10" limehd:keyIcon="@drawable/sym_keyboard_return_light" limehd:isModifier="true"
                 limehd:keyWidth="15%p" limehd:keyEdgeFlags="right"/>
@@ -165,7 +165,7 @@
         <Key limehd:codes="32" limehd:keyIcon="@drawable/sym_keyboard_space_light"
 
                 limehd:keyWidth="15%p" limehd:isRepeatable="true"/>
-        <Key limehd:keyLabel="."  limehd:popupKeyboard="@xml/popup_punctuation"
+        <Key limehd:codes="46" limehd:keyLabel="."  limehd:popupKeyboard="@xml/popup_punctuation"
                 limehd:keyWidth="10%p"/>
         <Key limehd:codes="10" limehd:keyIcon="@drawable/sym_keyboard_return_light" limehd:isModifier="true"
                 limehd:keyWidth="15%p" limehd:keyEdgeFlags="right"/>

--- a/LimeStudio/app/src/main/res/xml/symbols1.xml
+++ b/LimeStudio/app/src/main/res/xml/symbols1.xml
@@ -81,8 +81,7 @@
         <Key limehd:codes="32" limehd:keyIcon="@drawable/sym_keyboard_space_light"
 
         	 limehd:keyWidth="30%p" limehd:isRepeatable="true"/>
-        <Key limehd:codes="46" limehd:keyLabel="." 
-        						 limehd:popupKeyboard="@xml/popup_punctuation" 
+        <Key limehd:codes="46" limehd:keyLabel="." limehd:popupKeyboard="@xml/popup_punctuation"
         						limehd:keyWidth="10%p"/>
         <Key limehd:codes="-10" limehd:isModifier="true" limehd:keyLabel="中"  limehd:keyWidth="10%p" />
         <Key limehd:codes="10" limehd:keyIcon="@drawable/sym_keyboard_return_light" limehd:isModifier="true"

--- a/LimeStudio/app/src/main/res/xml/templime.xml
+++ b/LimeStudio/app/src/main/res/xml/templime.xml
@@ -78,9 +78,7 @@
         <Key limehd:codes="-9" limehd:keyLabel="中" limehd:isModifier="true" limehd:keyWidth="10%p" />
         <Key limehd:codes="44" limehd:keyLabel="," limehd:keyWidth="10%p"/>
         <Key limehd:codes="32" limehd:keyIcon="@drawable/sym_flat_keyboard_space"  limehd:keyWidth="30%p" limehd:isRepeatable="true"/>
-        <Key limehd:codes="46" 
-        		limehd:keyLabel="." 
-				 limehd:popupKeyboard="@xml/popup_c_punctuation"  
+        <Key limehd:codes="46" limehd:keyLabel="." limehd:popupKeyboard="@xml/popup_c_punctuation"
         		limehd:keyWidth="10%p"/>
         <Key limehd:codes="-2"  limehd:keyLabel="@string/label_symbol_key" limehd:isModifier="true"/>
         <Key limehd:codes="10" limehd:keyIcon="@drawable/sym_keyboard_return_light" limehd:isModifier="true" limehd:keyWidth="15%p" limehd:keyEdgeFlags="right"/>


### PR DESCRIPTION
task: https://app.clickup.com/t/3nn4dp2

說明： 正常情況下切換輸入法時
keycode = -10 （Eng --> Chi）會設定
mEnglishOnly = false;
mLIMEPref.setLanguageMode(false);

keycode = -9 (Chi --> Eng) 會設定
mEnglishOnly = true;
mLIMEPref.setLanguageMode(true);

然而因不明原因，會遇到切換中英文鍵盤時沒有重新設定 LanguageMode 導致事件被擋掉而不彈出 popup_c_punctuation